### PR TITLE
fixed VerifyAppInstalled() in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 verifyAppInstalled() {
   toolName=$1
-  if ! command -v "$toolName" &> /dev/null; then
+  if ! command -v "$toolName" > /dev/null 2>&1 ; then
     echo "Required app '${toolName}' is not installed"
     exit 1
   fi


### PR DESCRIPTION
- Fixed a bug in `install.sh` which caused `verifyAppInstalled()` to always exit, whether or not the program was installed.

This PR closes #2 - The issue was not with devmem2, but rather with the function which verifies that it is installed.