### PR TITLE
Updated dependencies for Ubuntu in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In short, I want to do many things in only one process: monitoring battery, GUI 
 ## Install
 
 1. **Install dependencies**:  
-Ubuntu: `sudo apt install devmem2 msr-tools libcgroup-tools powertop`  
+Ubuntu: `sudo apt install devmem2 msr-tools cgroup-tools powertop linux-tools-common`  
 Fedora: `sudo dnf install devmem2 msr-tools libcgroup-tools powertop`
 
 2. **Install nodejs**: Depends on which distribution you're using, please search on Google. You can install any version from v14 (v16.10.0 is recommended). Verify with `node --version`


### PR DESCRIPTION
This PR updates the dependencies listed in README.md for Ubuntu.

The two packages changed are:
-  `libcgroup-tools`, which is just called `cgroup-tools` on Ubuntu.
- `linux-tools-common`, which contains `turbostat`.